### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-DS_Store
+.DS_Store
 .idea/shelf
 /confluence/target
 /dependencies/repo


### PR DESCRIPTION
Originally the .gitignore file contains DS_Store. Changed it to .DS_Store now.