### PR TITLE
Update for solving STA/AP Concurrency issue (2/2/2025)

### DIFF
--- a/app/src/main/java/com/greybox/projectmesh/MainActivity.kt
+++ b/app/src/main/java/com/greybox/projectmesh/MainActivity.kt
@@ -56,6 +56,7 @@ import org.kodein.di.instance
 import java.io.File
 import java.util.Locale
 import java.net.InetAddress
+import com.greybox.projectmesh.util.checkStaApConcurrency
 
 class MainActivity : ComponentActivity(), DIAware {
     override val di by closestDI()
@@ -144,6 +145,25 @@ class MainActivity : ComponentActivity(), DIAware {
         CrashHandler.init(applicationContext,CrashScreenActivity::class.java)
         if (!isBatteryOptimizationDisabled(this)) {
             promptDisableBatteryOptimization(this)
+        }
+
+        val concurrencyKnown = settingPref.getBoolean("StaApConcurrencyKnown", false)
+
+        if(!concurrencyKnown){
+            checkStaApConcurrency(this){ supported ->
+                if (supported == null) {
+                    settingPref.edit()
+                        .putBoolean("StaApConcurrencySupported", false)
+                        .putBoolean("StaApConcurrencyKnown", false)
+                        .apply()
+                }
+                else{
+                    settingPref.edit()
+                        .putBoolean("StaApConcurrencySupported", supported)
+                        .putBoolean("StaApConcurrencyKnown", true)
+                        .apply()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/greybox/projectmesh/util/ConcurrencyCheck.kt
+++ b/app/src/main/java/com/greybox/projectmesh/util/ConcurrencyCheck.kt
@@ -1,0 +1,107 @@
+package com.greybox.projectmesh.util
+
+import android.app.AlertDialog
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.wifi.WifiManager
+import android.os.Build
+import androidx.compose.runtime.Composable
+import org.kodein.di.compose.localDI
+import org.kodein.di.instance
+
+@Composable
+fun getLatestConcurrencySupportAnswer(): Boolean {
+    val di = localDI()
+    val settingPref: SharedPreferences by di.instance(tag="settings")
+    val concurrencyKnown = settingPref.getBoolean("StaApConcurrencyKnown", false)
+    val concurrencySupported = settingPref.getBoolean("StaApConcurrencySupported", false)
+    return concurrencyKnown && concurrencySupported
+}
+
+/**
+ * Tries to check STA+AP concurrency support:
+ * 1) If Android 11+ -> use the official API.
+ * 2) If Android 9/10 -> try reflection to find 'isDualModeSupported()'.
+ * 3) If reflection fails -> prompt the user to do a manual check.
+ */
+fun checkStaApConcurrency(
+    context: Context,
+    onResult: (Boolean?) -> Unit
+) {
+    val wifiManager = context.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+        ?: return onResult(false)  // No WifiManager? Return false or handle gracefully.
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        // On Android 11+ (API 30+), we can use the official API
+        onResult(wifiManager.isStaApConcurrencySupported)
+    } else {
+        // Attempt reflection on Android 9 or 10
+        try {
+            val method = wifiManager.javaClass.getMethod("isDualModeSupported")
+            val result = method.invoke(wifiManager) as? Boolean ?: false
+            if(result){
+                showSupportDialog(context)
+            }
+            else{
+                showNotSupportDialog(context)
+            }
+            onResult(result)
+        } catch (e: NoSuchMethodException) {
+            // The hidden method doesn't exist on this device/ROM
+            showManualConcurrencyDialog(context, onResult)
+        } catch (e: Exception) {
+            // Reflection failed for some other reason
+            showManualConcurrencyDialog(context, onResult)
+        }
+    }
+}
+
+/**
+ * Shows a dialog explaining how to test concurrency manually,
+ * and get the user’s response.
+ */
+private fun showManualConcurrencyDialog(
+    context: Context,
+    onResult: (Boolean?) -> Unit
+) {
+    AlertDialog.Builder(context)
+        .setTitle("Manual Test Required")
+        .setMessage(
+            "We were unable to determine if your device supports " +
+                    "Wi-Fi + Hotspot concurrency. Please help us verify this feature using your " +
+                    "device's built-in Wi-Fi and Hotspot (Not this app) by following these steps:\n\n" +
+                    "1) Connect to a Wi-Fi network.\n" +
+                    "2) Enable your hotspot.\n" +
+                    "3) Check if Wi-Fi remains connected or if it’s disabled."
+        )
+        .setPositiveButton("Wi-Fi stayed connected") { _, _ ->
+            // User indicate concurrency works
+            onResult(true)
+        }
+        .setNegativeButton("Wi-Fi turned off") { _, _ ->
+            // User indicate concurrency does not work
+            onResult(false)
+        }
+        .setNeutralButton("Cancel") { _, _ ->
+            // User canceled without answer
+            onResult(null)
+        }
+        .show()
+}
+
+private fun showSupportDialog(context: Context) {
+    AlertDialog.Builder(context)
+        .setTitle("Great!")
+        .setMessage("Your device supports Wi-Fi + Hotspot Concurrency")
+        .setPositiveButton("Confirm!"){ _, _ -> }
+        .show()
+}
+
+private fun showNotSupportDialog(context: Context) {
+    AlertDialog.Builder(context)
+        .setTitle("Unfortunately, Your device does not Support Wi-Fi + Hotspot Concurrency")
+        .setMessage("If you believe your device should support this feature, " +
+                "Please tap Reset button on Settings page.")
+        .setPositiveButton("Confirm!"){ _, _ ->}
+        .show()
+}

--- a/app/src/main/res/values-cn/strings.xml
+++ b/app/src/main/res/values-cn/strings.xml
@@ -41,4 +41,9 @@
     <string name="cancel">取消</string>
 
     <string name="elapsed_time">耗时</string>
+
+    <string name="concurrency">STA/AP 并发</string>
+    <string name="manual_test">手动测试</string>
+    <string name="reset">重置</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -41,4 +41,9 @@
     <string name="cancel">Cancelar</string>
 
     <string name="elapsed_time">Tiempo transcurrido</string>
+
+    <string name="concurrency">Concurrencia STA/AP</string>
+    <string name="manual_test">Prueba Manual</string>
+    <string name="reset">Restablecer</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,5 +53,9 @@
 
     <string name="elapsed_time">Elapsed time</string>
 
+    <string name="concurrency"> STA/AP Concurrency</string>
+    <string name="manual_test">Manual Test</string>
+    <string name="reset">Reset</string>
+
 
 </resources>


### PR DESCRIPTION
This update only focuses on implementing the logic for checking STA/AP concurrency on Android 10 and below:

1. For Android 11 and above -> Use the official API.
2. For Android 10 and below -> Attempt to use "isDualModeSupported" (not available in official ROMs but may exist on certain branded Android devices).
3. If method 2 fails -> Prompt the user to perform a manual test and provide feedback.
4. If the user does not respond -> The concurrency feature will default to false.
5. Manual test reset → Users can reset their manual test answer by tapping the Reset button in the Settings screen (this button is only available on Android 10 and below).