### PR TITLE
mvvm: move network node actions to NetworkScreenViewModel

### DIFF
--- a/app/src/main/java/com/greybox/projectmesh/viewModel/NetworkScreenViewModel.kt
+++ b/app/src/main/java/com/greybox/projectmesh/viewModel/NetworkScreenViewModel.kt
@@ -32,8 +32,10 @@ data class NetworkScreenModel(
 class NetworkScreenViewModel(di:DI, savedStateHandle: SavedStateHandle): ViewModel() {
     // _uiState will be updated whenever there is a change in the UI state
     private val _uiState = MutableStateFlow(NetworkScreenModel())
+
     // uiState is a read-only property that shows the current UI state
     val uiState: Flow<NetworkScreenModel> = _uiState.asStateFlow()
+
     // di is used to get the AndroidVirtualNode instance
     private val node: AndroidVirtualNode by di.instance()
     private val appServer: AppServer by di.instance()
@@ -54,7 +56,8 @@ class NetworkScreenViewModel(di:DI, savedStateHandle: SavedStateHandle): ViewMod
 
                 // For each disconnected node, notify DeviceStatusManager
                 disconnectedNodes.forEach { nodeAddress ->
-                    val ipAddress = InetAddress.getByAddress(nodeAddress.addressToByteArray()).hostAddress
+                    val ipAddress =
+                        InetAddress.getByAddress(nodeAddress.addressToByteArray()).hostAddress
                     DeviceStatusManager.handleNetworkDisconnect(ipAddress)
                     Log.d("NetworkScreenViewModel", "Detected disconnection of node: $ipAddress")
                 }
@@ -77,11 +80,11 @@ class NetworkScreenViewModel(di:DI, savedStateHandle: SavedStateHandle): ViewMod
                         allNodes = allNodesWithTest,
                         // update the ssid of the connecting station
                         connectingInProgressSsid =
-                        if (nodeState.wifiState.wifiStationState.status == WifiStationState.Status.CONNECTING) {
-                            nodeState.wifiState.wifiStationState.config?.ssid
-                        } else {
-                            null
-                        }
+                            if (nodeState.wifiState.wifiStationState.status == WifiStationState.Status.CONNECTING) {
+                                nodeState.wifiState.wifiStationState.config?.ssid
+                            } else {
+                                null
+                            }
                     )
                 }
 
@@ -187,13 +190,30 @@ class NetworkScreenViewModel(di:DI, savedStateHandle: SavedStateHandle): ViewMod
                 delay(30000)
             }
         }
-    }
+
     */
-        fun getDeviceName(wifiAddress: Int) {
-            viewModelScope.launch {
-                val inetAddress = InetAddress.getByAddress(wifiAddress.addressToByteArray())
-                appServer.sendDeviceName(inetAddress)
+    }
+
+    fun onNodeSelected(ipAddress: String) {
+        viewModelScope.launch {
+            try {
+                val addr = InetAddress.getByName(ipAddress)
+                appServer.requestRemoteUserInfo(addr)
+                appServer.pushUserInfoTo(addr)
+            } catch (e: Exception) {
+                Log.e("NetworkScreenViewModel", "Failed to request user info for $ipAddress", e)
             }
         }
     }
+
+    fun getDeviceName(wifiAddress: Int) {
+        viewModelScope.launch {
+            val inetAddress = InetAddress.getByAddress(wifiAddress.addressToByteArray())
+            appServer.sendDeviceName(inetAddress)
+        }
+    }
 }
+
+
+
+

--- a/app/src/main/java/com/greybox/projectmesh/viewModel/NetworkScreenViewModel.kt
+++ b/app/src/main/java/com/greybox/projectmesh/viewModel/NetworkScreenViewModel.kt
@@ -8,6 +8,8 @@ import com.greybox.projectmesh.DeviceStatusManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
 import org.kodein.di.DI
 import com.greybox.projectmesh.server.AppServer
@@ -197,7 +199,9 @@ class NetworkScreenViewModel(di:DI, savedStateHandle: SavedStateHandle): ViewMod
     fun onNodeSelected(ipAddress: String) {
         viewModelScope.launch {
             try {
-                val addr = InetAddress.getByName(ipAddress)
+                val addr = withContext(Dispatchers.IO) {
+                    InetAddress.getByName(ipAddress)
+                }
                 appServer.requestRemoteUserInfo(addr)
                 appServer.pushUserInfoTo(addr)
             } catch (e: Exception) {

--- a/app/src/main/java/com/greybox/projectmesh/viewModel/NetworkScreenViewModel.kt
+++ b/app/src/main/java/com/greybox/projectmesh/viewModel/NetworkScreenViewModel.kt
@@ -196,17 +196,16 @@ class NetworkScreenViewModel(di:DI, savedStateHandle: SavedStateHandle): ViewMod
     */
     }
 
-    fun onNodeSelected(ipAddress: String) {
-        viewModelScope.launch {
-            try {
-                val addr = withContext(Dispatchers.IO) {
-                    InetAddress.getByName(ipAddress)
-                }
-                appServer.requestRemoteUserInfo(addr)
-                appServer.pushUserInfoTo(addr)
-            } catch (e: Exception) {
-                Log.e("NetworkScreenViewModel", "Failed to request user info for $ipAddress", e)
+    suspend fun onNodeSelected(ipAddress: String) {
+        try {
+            val addr = withContext(Dispatchers.IO) {
+                InetAddress.getByName(ipAddress)
             }
+            appServer.requestRemoteUserInfo(addr)
+            appServer.pushUserInfoTo(addr)
+        } catch (e: Exception) {
+            Timber.tag("NetworkScreenViewModel")git stat
+                .e(e, "Failed to request user info for $ipAddress")
         }
     }
 

--- a/app/src/main/java/com/greybox/projectmesh/views/NetworkScreen.kt
+++ b/app/src/main/java/com/greybox/projectmesh/views/NetworkScreen.kt
@@ -9,14 +9,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.greybox.projectmesh.ViewModelFactory
-import com.greybox.projectmesh.viewModel.HomeScreenViewModel
 import com.greybox.projectmesh.viewModel.NetworkScreenModel
 import com.greybox.projectmesh.viewModel.NetworkScreenViewModel
 import org.kodein.di.compose.localDI
 import com.greybox.projectmesh.extension.WifiListItem
-import com.greybox.projectmesh.server.AppServer
-import java.net.InetAddress
-import org.kodein.di.instance
+
 
 @Composable
 fun NetworkScreen(
@@ -30,8 +27,7 @@ fun NetworkScreen(
 ) {
     // declare the UI state, we can use the uiState to access the current state of the viewModel
     val uiState: NetworkScreenModel by viewModel.uiState.collectAsState(initial = NetworkScreenModel())
-    val di = localDI()
-    val appServer: AppServer by di.instance()
+
 
     // display all the connected station
     LazyColumn{
@@ -43,12 +39,7 @@ fun NetworkScreen(
                 wifiAddress = eachItem.key,
                 wifiEntry = eachItem.value,
                 onClick = { ipAddress ->
-                    //request user info when clicking
-                    val addr = InetAddress.getByName(ipAddress)
-                    appServer.requestRemoteUserInfo(addr)
-                    appServer.pushUserInfoTo(addr)
-
-                    //Navigate to Ping Screen
+                    viewModel.onNodeSelected(ipAddress)
                     onNodeClick(ipAddress)
                 }
             )


### PR DESCRIPTION
- Moved node interaction logic from NetworkScreen UI into NetworkScreenViewModel.
- This keeps the UI layer focused on rendering and navigation while the ViewModel handles network related actions only.
